### PR TITLE
Add Mutex for thread safety, as evidenced by tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,6 @@ root = true
 indent_style = space
 indent_size = 2
 tab_width = 8
+
+[Makefile]
+indent_style = tab

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,6 @@
 
 # Applied `make format`
 ffdff31e91817be06d634dc0a9076d8b6472e155
+
+# chore: Format C/C++ in 80 columns
+7844a448b8f35d1ba4f4afe7ca9ab8874df6f01b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# .git-blame-ignore-revs
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view
+# https://git-scm.com/docs/git-blame#Documentation/git-blame.txt---ignore-revs-fileltfilegt
+
+# consistent formatting with clang-format (one-time)
+5a5a92d28ccca69c233076d0e22c395d213f18da
+
+# Applied `make format`
+ffdff31e91817be06d634dc0a9076d8b6472e155

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 all:
 	$(MAKE) -C c-layer $@
 	$(MAKE) -C c-example $@
+# TODO: put bindgen to build.rs
+	(cd rust/zypp-agama-sys; bindgen --merge-extern-blocks headers.h -o src/bindings.rs -- -I../../c-layer/include)
 	(cd rust; cargo build)
 	doxygen
 

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ all:
 check:
 	$(MAKE) -C c-layer $@
 	$(MAKE) -C c-example $@
-# These tests cannot be run in multiple threads
-# because libzypp is not thread safe, and we do not mutex it (yet)
-	(cd rust; cargo test -- --test-threads=1)
+	(cd rust; cargo test)
 
 clean:
 	$(MAKE) -C c-layer $@

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,19 @@ all:
 	doxygen
 
 check:
+	git ls-files | grep '\.[ch]' | \
+	  xargs --verbose clang-format --style="{BasedOnStyle: llvm, ColumnLimit: 120}" --dry-run
 	$(MAKE) -C c-layer $@
 	$(MAKE) -C c-example $@
+	(cd rust; cargo fmt -- --check)
 	(cd rust; cargo test)
 
 clean:
 	$(MAKE) -C c-layer $@
 	$(MAKE) -C c-example $@
 	(cd rust; cargo clean)
+
+format:
+	git ls-files | grep '\.[ch]' | \
+	  xargs --verbose clang-format --style="{BasedOnStyle: llvm, ColumnLimit: 120}" -i
+	(cd rust; cargo fmt)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 
 check:
 	git ls-files | grep '\.[ch]' | \
-	  xargs --verbose clang-format --style="{BasedOnStyle: llvm, ColumnLimit: 120}" --dry-run
+	  xargs --verbose clang-format --style=llvm --dry-run
 	$(MAKE) -C c-layer $@
 	$(MAKE) -C c-example $@
 	(cd rust; cargo fmt -- --check)
@@ -21,5 +21,5 @@ clean:
 
 format:
 	git ls-files | grep '\.[ch]' | \
-	  xargs --verbose clang-format --style="{BasedOnStyle: llvm, ColumnLimit: 120}" -i
+	  xargs --verbose clang-format --style=llvm -i
 	(cd rust; cargo fmt)

--- a/c-example/main.c
+++ b/c-example/main.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[]) {
     root = argv[1];
   printf("List of repos:\n");
   const char *prefix = "Loading '/'"; // TODO: wrong report with changed root
-  init_target(root, &status, progress, (void *)prefix);
+  struct Zypp *zypp = init_target(root, &status, progress, (void *)prefix);
   if (status.state != STATE_SUCCEED) {
     printf("init ERROR!: %s\n", status.error);
     result = EXIT_FAILURE;
@@ -57,7 +57,7 @@ int main(int argc, char *argv[]) {
   free_status(&status);
 
   printf("Existing repos:");
-  struct RepositoryList list = list_repositories(&status);
+  struct RepositoryList list = list_repositories(zypp, &status);
   if (status.state != STATE_SUCCEED) {
     printf("list_repositories ERROR!: %s\n", status.error);
     result = EXIT_FAILURE;
@@ -71,7 +71,9 @@ int main(int argc, char *argv[]) {
 
   printf("\n\n");
   printf("Adding new repo with Agama Devel\n");
-  add_repository("agama", "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/openSUSE_Tumbleweed/", &status, zypp_progress, NULL);
+  add_repository(zypp, "agama",
+                 "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/openSUSE_Tumbleweed/",
+                 &status, zypp_progress, NULL);
   if (status.state != STATE_SUCCEED) {
     printf("failed to add repo!: %s\n", status.error);
     result = EXIT_FAILURE;
@@ -79,7 +81,7 @@ int main(int argc, char *argv[]) {
   }
   free_status(&status);
   printf("Refreshing it");
-  refresh_repository("agama", &status, &download_callbacks);
+  refresh_repository(zypp, "agama", &status, &download_callbacks);
   if (status.state != STATE_SUCCEED) {
     printf("refresh ERROR!: %s\n", status.error);
     goto repoerr;
@@ -90,6 +92,6 @@ repoerr:
   free_repository_list(&list);
 norepo:
   free_status(&status);
-  free_zypp();
+  free_zypp(zypp);
   return result;
 }

--- a/c-example/main.c
+++ b/c-example/main.c
@@ -14,22 +14,28 @@ bool zypp_progress(struct ProgressData data, void *user_data) {
   return true;
 }
 
-void download_progress_start(const char *url, const char *localfile, void *user_data) {
+void download_progress_start(const char *url, const char *localfile,
+                             void *user_data) {
   printf("Starting download of %s to %s\n", url, localfile);
 }
 
-bool download_progress_progress(int value, const char *url, double bps_avg, double bps_current, void *user_data) {
-  printf("Downloading %s with %i%% (speed: now %f avg %f)\n", url, value, bps_current, bps_avg);
+bool download_progress_progress(int value, const char *url, double bps_avg,
+                                double bps_current, void *user_data) {
+  printf("Downloading %s with %i%% (speed: now %f avg %f)\n", url, value,
+         bps_current, bps_avg);
   return true;
 }
 
-enum PROBLEM_RESPONSE download_progress_problem(const char *url, int error, const char *description, void *user_data) {
+enum PROBLEM_RESPONSE download_progress_problem(const char *url, int error,
+                                                const char *description,
+                                                void *user_data) {
   printf("Download ERROR for %s: %s\n", url, description);
   printf("Aborting...\n");
   return PROBLEM_ABORT;
 }
 
-void download_progress_finish(const char *url, int error, const char *reason, void *user_data) {
+void download_progress_finish(const char *url, int error, const char *reason,
+                              void *user_data) {
   printf("Download of %s finished with status %d (%s)\n", url, error, reason);
 }
 
@@ -69,7 +75,8 @@ int main(int argc, char *argv[]) {
   printf("\n\n");
   printf("Adding new repo with Agama Devel\n");
   add_repository(zypp, "agama",
-                 "https://download.opensuse.org/repositories/systemsmanagement:/Agama:/Devel/openSUSE_Tumbleweed/",
+                 "https://download.opensuse.org/repositories/"
+                 "systemsmanagement:/Agama:/Devel/openSUSE_Tumbleweed/",
                  &status, zypp_progress, NULL);
   if (status.state != STATE_SUCCEED) {
     printf("failed to add repo!: %s\n", status.error);

--- a/c-example/main.c
+++ b/c-example/main.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[]) {
   if (status.state != STATE_SUCCEED) {
     printf("init ERROR!: %s\n", status.error);
     result = EXIT_FAILURE;
-    goto norepo;
+    goto nozypp;
   }
   free_status(&status);
 
@@ -67,6 +67,7 @@ int main(int argc, char *argv[]) {
     goto norepo;
   }
   free_status(&status);
+
   for (unsigned i = 0; i < list.size; ++i) {
     struct Repository *repo = list.repos + i;
     printf("repo %i: %s\n", i, repo->userName);
@@ -94,7 +95,8 @@ int main(int argc, char *argv[]) {
 repoerr:
   free_repository_list(&list);
 norepo:
-  free_status(&status);
   free_zypp(zypp);
+nozypp:
+  free_status(&status);
   return result;
 }

--- a/c-example/main.c
+++ b/c-example/main.c
@@ -1,9 +1,9 @@
 #include "callbacks.h"
 #include "lib.h"
 #include "repository.h"
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 
 void progress(const char *text, unsigned stage, unsigned total, void *data) {
   printf("(%s) %u/%u: %s\n", (const char *)data, stage, total, text);
@@ -37,13 +37,10 @@ int main(int argc, char *argv[]) {
   int result = EXIT_SUCCESS;
   struct Status status;
   struct DownloadProgressCallbacks download_callbacks = {
-    download_progress_start, NULL,
-    download_progress_progress, NULL,
-    download_progress_problem, NULL,
-    download_progress_finish, NULL
-  };
+      download_progress_start,   NULL, download_progress_progress, NULL,
+      download_progress_problem, NULL, download_progress_finish,   NULL};
 
-  char * root = "/";
+  char *root = "/";
   if (argc > 1)
     root = argv[1];
   printf("List of repos:\n");
@@ -86,7 +83,6 @@ int main(int argc, char *argv[]) {
     printf("refresh ERROR!: %s\n", status.error);
     goto repoerr;
   }
-
 
 repoerr:
   free_repository_list(&list);

--- a/c-layer/include/callbacks.h
+++ b/c-layer/include/callbacks.h
@@ -8,9 +8,9 @@ extern "C" {
 #endif
 
 struct ProgressData {
-  // TODO: zypp also reports min/max so it can be either percent, min/max or just alive progress.
-  // Should we expose all of them?
-  // progress value is either percent or -1 which means just keep alive progress
+  // TODO: zypp also reports min/max so it can be either percent, min/max or
+  // just alive progress. Should we expose all of them? progress value is either
+  // percent or -1 which means just keep alive progress
   long long value;
   // pointer to progress name. Owned by zypp, so lives only as long as callback
   const char *name;
@@ -18,18 +18,24 @@ struct ProgressData {
 
 // Progress reporting callback passed to libzypp.
 // zypp_data is ProgressData get from zypp
-// user_data is never touched by method and is used only to pass local data for callback
+// user_data is never touched by method and is used only to pass local data for
+// callback
 /// @return true to continue, false to abort. Can be ignored
-typedef bool (*ZyppProgressCallback)(struct ProgressData zypp_data, void *user_data);
+typedef bool (*ZyppProgressCallback)(struct ProgressData zypp_data,
+                                     void *user_data);
 void set_zypp_progress_callback(ZyppProgressCallback progress, void *user_data);
 
 enum PROBLEM_RESPONSE { PROBLEM_RETRY, PROBLEM_ABORT, PROBLEM_IGNORE };
-typedef void (*ZyppDownloadStartCallback)(const char *url, const char *localfile, void *user_data);
-typedef bool (*ZyppDownloadProgressCallback)(int value, const char *url, double bps_avg, double bps_current,
+typedef void (*ZyppDownloadStartCallback)(const char *url,
+                                          const char *localfile,
+                                          void *user_data);
+typedef bool (*ZyppDownloadProgressCallback)(int value, const char *url,
+                                             double bps_avg, double bps_current,
                                              void *user_data);
-typedef enum PROBLEM_RESPONSE (*ZyppDownloadProblemCallback)(const char *url, int error, const char *description,
-                                                             void *user_data);
-typedef void (*ZyppDownloadFinishCallback)(const char *url, int error, const char *reason, void *user_data);
+typedef enum PROBLEM_RESPONSE (*ZyppDownloadProblemCallback)(
+    const char *url, int error, const char *description, void *user_data);
+typedef void (*ZyppDownloadFinishCallback)(const char *url, int error,
+                                           const char *reason, void *user_data);
 
 // progress for downloading files. There are 4 callbacks:
 // 1. start for start of download

--- a/c-layer/include/lib.h
+++ b/c-layer/include/lib.h
@@ -115,7 +115,7 @@ struct PatternInfos {
 
 /// Get Pattern details.
 /// Unknown patterns are simply omitted from the result. Match by PatternInfo.name, not by index.
-struct PatternInfos get_patterns_info(struct PatternNames names, struct Status *status) noexcept;
+struct PatternInfos get_patterns_info(struct Zypp *_zypp, struct PatternNames names, struct Status *status) noexcept;
 void free_pattern_infos(const struct PatternInfos *infos) noexcept;
 
 void import_gpg_key(struct Zypp *zypp, const char *const pathname, struct Status *status) noexcept;

--- a/c-layer/include/lib.h
+++ b/c-layer/include/lib.h
@@ -35,19 +35,24 @@ struct Zypp;
 /// Progress reporting callback used by methods that takes longer.
 /// @param text  text for user describing what is happening now
 /// @param stage current stage number starting with 0
-/// @param total count of stages. It should not change during single call of method.
-/// @param user_data is never touched by method and is used only to pass local data for callback
-/// @todo Do we want to support response for callback that allows early exit of execution?
-typedef void (*ProgressCallback)(const char *text, unsigned stage, unsigned total, void *user_data);
+/// @param total count of stages. It should not change during single call of
+/// method.
+/// @param user_data is never touched by method and is used only to pass local
+/// data for callback
+/// @todo Do we want to support response for callback that allows early exit of
+/// execution?
+typedef void (*ProgressCallback)(const char *text, unsigned stage,
+                                 unsigned total, void *user_data);
 /// Initialize Zypp target (where to install packages to).
-/// The returned zypp context is not thread safe and should be protected by a mutex
-/// in the calling layer.
+/// The returned zypp context is not thread safe and should be protected by a
+/// mutex in the calling layer.
 /// @param root
 /// @param[out] status
 /// @param progress
 /// @param user_data
 /// @return zypp context
-struct Zypp *init_target(const char *root, struct Status *status, ProgressCallback progress, void *user_data) noexcept;
+struct Zypp *init_target(const char *root, struct Status *status,
+                         ProgressCallback progress, void *user_data) noexcept;
 
 enum RESOLVABLE_KIND {
   RESOLVABLE_PRODUCT,
@@ -64,7 +69,8 @@ enum RESOLVABLE_SELECTED {
   /// match TransactByValue::SOLVER
   SOLVER_SELECTED,
   /// installation proposal selects resolvable
-  /// match TransactByValue::APPL_{LOW,HIGH} we do not need both, so we use just one value
+  /// match TransactByValue::APPL_{LOW,HIGH} we do not need both, so we use just
+  /// one value
   APPLICATION_SELECTED,
   /// user select resolvable for installation
   /// match TransactByValue::USER
@@ -75,18 +81,24 @@ enum RESOLVABLE_SELECTED {
 /// @param zypp see \ref init_target
 /// @param name resolvable name
 /// @param kind kind of resolvable
-/// @param who who do selection. If NOT_SELECTED is used, it will be empty operation.
+/// @param who who do selection. If NOT_SELECTED is used, it will be empty
+/// operation.
 /// @param[out] status (will overwrite existing contents)
-void resolvable_select(struct Zypp *zypp, const char *name, enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who,
+void resolvable_select(struct Zypp *zypp, const char *name,
+                       enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who,
                        struct Status *status) noexcept;
 
-/// Unselect resolvable for installation. It can still be installed as dependency.
+/// Unselect resolvable for installation. It can still be installed as
+/// dependency.
 /// @param zypp see \ref init_target
 /// @param name resolvable name
 /// @param kind kind of resolvable
-/// @param who who do unselection. Only unselect if it is higher or equal level then who do the selection.
+/// @param who who do unselection. Only unselect if it is higher or equal level
+/// then who do the selection.
 /// @param[out] status (will overwrite existing contents)
-void resolvable_unselect(struct Zypp *zypp, const char *name, enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who,
+void resolvable_unselect(struct Zypp *zypp, const char *name,
+                         enum RESOLVABLE_KIND kind,
+                         enum RESOLVABLE_SELECTED who,
                          struct Status *status) noexcept;
 
 struct PatternNames {
@@ -114,11 +126,15 @@ struct PatternInfos {
 };
 
 /// Get Pattern details.
-/// Unknown patterns are simply omitted from the result. Match by PatternInfo.name, not by index.
-struct PatternInfos get_patterns_info(struct Zypp *_zypp, struct PatternNames names, struct Status *status) noexcept;
+/// Unknown patterns are simply omitted from the result. Match by
+/// PatternInfo.name, not by index.
+struct PatternInfos get_patterns_info(struct Zypp *_zypp,
+                                      struct PatternNames names,
+                                      struct Status *status) noexcept;
 void free_pattern_infos(const struct PatternInfos *infos) noexcept;
 
-void import_gpg_key(struct Zypp *zypp, const char *const pathname, struct Status *status) noexcept;
+void import_gpg_key(struct Zypp *zypp, const char *const pathname,
+                    struct Status *status) noexcept;
 
 /// Runs solver
 /// @param zypp see \ref init_target

--- a/c-layer/include/lib.h
+++ b/c-layer/include/lib.h
@@ -57,7 +57,6 @@ enum RESOLVABLE_KIND {
   RESOLVABLE_PATTERN,
 };
 
-
 enum RESOLVABLE_SELECTED {
   /// resolvable won't be installed
   NOT_SELECTED,

--- a/c-layer/include/lib.h
+++ b/c-layer/include/lib.h
@@ -29,6 +29,9 @@ struct Status {
 };
 void free_status(struct Status *s) noexcept;
 
+/// Opaque Zypp context
+struct Zypp;
+
 /// Progress reporting callback used by methods that takes longer.
 /// @param text  text for user describing what is happening now
 /// @param stage current stage number starting with 0
@@ -36,12 +39,15 @@ void free_status(struct Status *s) noexcept;
 /// @param user_data is never touched by method and is used only to pass local data for callback
 /// @todo Do we want to support response for callback that allows early exit of execution?
 typedef void (*ProgressCallback)(const char *text, unsigned stage, unsigned total, void *user_data);
-/// Initialize Zypp target (where to install packages to)
+/// Initialize Zypp target (where to install packages to).
+/// The returned zypp context is not thread safe and should be protected by a mutex
+/// in the calling layer.
 /// @param root
 /// @param[out] status
 /// @param progress
 /// @param user_data
-void init_target(const char *root, struct Status *status, ProgressCallback progress, void *user_data) noexcept;
+/// @return zypp context
+struct Zypp *init_target(const char *root, struct Status *status, ProgressCallback progress, void *user_data) noexcept;
 
 enum RESOLVABLE_KIND {
   RESOLVABLE_PRODUCT,
@@ -67,19 +73,22 @@ enum RESOLVABLE_SELECTED {
 };
 
 /// Marks resolvable for installation
+/// @param zypp see \ref init_target
 /// @param name resolvable name
 /// @param kind kind of resolvable
 /// @param who who do selection. If NOT_SELECTED is used, it will be empty operation.
 /// @param[out] status (will overwrite existing contents)
-void resolvable_select(const char *name, enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who, struct Status *status) noexcept;
+void resolvable_select(struct Zypp *zypp, const char *name, enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who,
+                       struct Status *status) noexcept;
 
 /// Unselect resolvable for installation. It can still be installed as dependency.
+/// @param zypp see \ref init_target
 /// @param name resolvable name
 /// @param kind kind of resolvable
 /// @param who who do unselection. Only unselect if it is higher or equal level then who do the selection.
 /// @param[out] status (will overwrite existing contents)
-void resolvable_unselect(const char *name, enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who, struct Status *status) noexcept;
-
+void resolvable_unselect(struct Zypp *zypp, const char *name, enum RESOLVABLE_KIND kind, enum RESOLVABLE_SELECTED who,
+                         struct Status *status) noexcept;
 
 struct PatternNames {
   /// names of patterns
@@ -110,15 +119,16 @@ struct PatternInfos {
 struct PatternInfos get_patterns_info(struct PatternNames names, struct Status *status) noexcept;
 void free_pattern_infos(const struct PatternInfos *infos) noexcept;
 
-void import_gpg_key(const char* const pathname, struct Status *status) noexcept;
+void import_gpg_key(struct Zypp *zypp, const char *const pathname, struct Status *status) noexcept;
 
 /// Runs solver
+/// @param zypp see \ref init_target
 /// @param[out] status (will overwrite existing contents)
 /// @return true if solver pass and false if it found some dependency issues
-bool run_solver(struct Status *status) noexcept;
+bool run_solver(struct Zypp *zypp, struct Status *status) noexcept;
 
 /// the last call that will free all pointers to zypp holded by agama
-void free_zypp() noexcept;
+void free_zypp(struct Zypp *zypp) noexcept;
 
 #ifdef __cplusplus
 }

--- a/c-layer/include/repository.h
+++ b/c-layer/include/repository.h
@@ -26,7 +26,8 @@ struct RepositoryList {
 /// when no longer needed, use \ref free_repository_list to release memory
 /// @param zypp see \ref init_target
 /// @param[out] status (will overwrite existing contents)
-struct RepositoryList list_repositories(struct Zypp *zypp, struct Status *status) noexcept;
+struct RepositoryList list_repositories(struct Zypp *zypp,
+                                        struct Status *status) noexcept;
 
 void free_repository_list(struct RepositoryList *repo_list) noexcept;
 
@@ -37,8 +38,9 @@ void free_repository_list(struct RepositoryList *repo_list) noexcept;
 /// @param[out] status (will overwrite existing contents)
 /// @param callback pointer to function with callback or NULL
 /// @param user_data
-void add_repository(struct Zypp *zypp, const char *alias, const char *url, struct Status *status,
-                    ZyppProgressCallback callback, void *user_data) noexcept;
+void add_repository(struct Zypp *zypp, const char *alias, const char *url,
+                    struct Status *status, ZyppProgressCallback callback,
+                    void *user_data) noexcept;
 
 /// Removes repository from repo manager
 /// @param zypp see \ref init_target
@@ -46,20 +48,26 @@ void add_repository(struct Zypp *zypp, const char *alias, const char *url, struc
 /// @param[out] status (will overwrite existing contents)
 /// @param callback pointer to function with callback or NULL
 /// @param user_data
-void remove_repository(struct Zypp *zypp, const char *alias, struct Status *status, ZyppProgressCallback callback,
+void remove_repository(struct Zypp *zypp, const char *alias,
+                       struct Status *status, ZyppProgressCallback callback,
                        void *user_data) noexcept;
 
 ///
 /// @param zypp see \ref init_target
 /// @param alias alias of repository to refresh
 /// @param[out] status (will overwrite existing contents)
-/// @param callbacks pointer to struct with callbacks or NULL if no progress is needed
-void refresh_repository(struct Zypp *zypp, const char *alias, struct Status *status,
+/// @param callbacks pointer to struct with callbacks or NULL if no progress is
+/// needed
+void refresh_repository(struct Zypp *zypp, const char *alias,
+                        struct Status *status,
                         struct DownloadProgressCallbacks *callbacks) noexcept;
 
-void build_repository_cache(struct Zypp *zypp, const char *alias, struct Status *status, ZyppProgressCallback callback,
+void build_repository_cache(struct Zypp *zypp, const char *alias,
+                            struct Status *status,
+                            ZyppProgressCallback callback,
                             void *user_data) noexcept;
-void load_repository_cache(struct Zypp *zypp, const char *alias, struct Status *status) noexcept;
+void load_repository_cache(struct Zypp *zypp, const char *alias,
+                           struct Status *status) noexcept;
 
 #ifdef __cplusplus
 }

--- a/c-layer/include/repository.h
+++ b/c-layer/include/repository.h
@@ -24,37 +24,42 @@ struct RepositoryList {
 
 /// repository array in list.
 /// when no longer needed, use \ref free_repository_list to release memory
+/// @param zypp see \ref init_target
 /// @param[out] status (will overwrite existing contents)
-struct RepositoryList list_repositories(struct Status *status) noexcept;
+struct RepositoryList list_repositories(struct Zypp *zypp, struct Status *status) noexcept;
 
 void free_repository_list(struct RepositoryList *repo_list) noexcept;
 
 /// Adds repository to repo manager
+/// @param zypp see \ref init_target
 /// @param alias have to be unique
 /// @param url can contain repo variables
 /// @param[out] status (will overwrite existing contents)
 /// @param callback pointer to function with callback or NULL
 /// @param user_data
-void add_repository(const char *alias, const char *url, struct Status *status, ZyppProgressCallback callback,
-                    void *user_data) noexcept;
+void add_repository(struct Zypp *zypp, const char *alias, const char *url, struct Status *status,
+                    ZyppProgressCallback callback, void *user_data) noexcept;
 
 /// Removes repository from repo manager
+/// @param zypp see \ref init_target
 /// @param alias have to be unique
 /// @param[out] status (will overwrite existing contents)
 /// @param callback pointer to function with callback or NULL
 /// @param user_data
-void remove_repository(const char *alias, struct Status *status, ZyppProgressCallback callback,
+void remove_repository(struct Zypp *zypp, const char *alias, struct Status *status, ZyppProgressCallback callback,
                        void *user_data) noexcept;
 
 ///
+/// @param zypp see \ref init_target
 /// @param alias alias of repository to refresh
 /// @param[out] status (will overwrite existing contents)
 /// @param callbacks pointer to struct with callbacks or NULL if no progress is needed
-void refresh_repository(const char *alias, struct Status *status, struct DownloadProgressCallbacks *callbacks) noexcept;
+void refresh_repository(struct Zypp *zypp, const char *alias, struct Status *status,
+                        struct DownloadProgressCallbacks *callbacks) noexcept;
 
-void build_repository_cache(const char *alias, struct Status *status, ZyppProgressCallback callback,
+void build_repository_cache(struct Zypp *zypp, const char *alias, struct Status *status, ZyppProgressCallback callback,
                             void *user_data) noexcept;
-void load_repository_cache(const char *alias, struct Status *status) noexcept;
+void load_repository_cache(struct Zypp *zypp, const char *alias, struct Status *status) noexcept;
 
 #ifdef __cplusplus
 }

--- a/c-layer/internal/callbacks.hxx
+++ b/c-layer/internal/callbacks.hxx
@@ -2,12 +2,14 @@
 #define C_CALLBACKS_HXX_
 
 #include "callbacks.h"
-// C++ specific code call that cannot be used from C. Used to pass progress class between o files.
+// C++ specific code call that cannot be used from C. Used to pass progress
+// class between o files.
 #include <zypp-core/ui/progressdata.h>
-zypp::ProgressData::ReceiverFnc create_progress_callback(ZyppProgressCallback progress, void *user_data);
+zypp::ProgressData::ReceiverFnc
+create_progress_callback(ZyppProgressCallback progress, void *user_data);
 
-// pair of set and unset calls. Struct for callbacks has to live as least as long as unset is call.
-// idea is to wrap it around call that do some download
+// pair of set and unset calls. Struct for callbacks has to live as least as
+// long as unset is call. idea is to wrap it around call that do some download
 void set_zypp_download_callbacks(struct DownloadProgressCallbacks *callbacks);
 void unset_zypp_download_callbacks();
 

--- a/c-layer/internal/helpers.hxx
+++ b/c-layer/internal/helpers.hxx
@@ -5,6 +5,8 @@
 /// Macro in case of programmer error. We do not use exceptions do to usage of noexpect
 /// in all places to avoid flowing exceptions to our pure C API.
 /// It basically print message to stderr and abort
-#define PANIC(...) fprintf(stderr, __VA_ARGS__); abort()
+#define PANIC(...)                                                                                                     \
+  fprintf(stderr, __VA_ARGS__);                                                                                        \
+  abort()
 
 #endif

--- a/c-layer/internal/helpers.hxx
+++ b/c-layer/internal/helpers.hxx
@@ -2,11 +2,11 @@
 #define C_HELPERS_HXX_
 
 #include <stdlib.h>
-/// Macro in case of programmer error. We do not use exceptions do to usage of noexpect
-/// in all places to avoid flowing exceptions to our pure C API.
-/// It basically print message to stderr and abort
-#define PANIC(...)                                                                                                     \
-  fprintf(stderr, __VA_ARGS__);                                                                                        \
+/// Macro in case of programmer error. We do not use exceptions do to usage of
+/// noexpect in all places to avoid flowing exceptions to our pure C API. It
+/// basically print message to stderr and abort
+#define PANIC(...)                                                             \
+  fprintf(stderr, __VA_ARGS__);                                                \
   abort()
 
 #endif

--- a/c-layer/lib.cxx
+++ b/c-layer/lib.cxx
@@ -96,6 +96,13 @@ static zypp::ZYpp::Ptr zypp_ptr() {
 // target and merge it in rust
 struct Zypp *init_target(const char *root, struct Status *status,
                          ProgressCallback progress, void *user_data) noexcept {
+  if (the_zypp.zypp_pointer != NULL) {
+    status->state = status->STATE_FAILED;
+    status->error = strdup("Cannot have two init_target concurrently, "
+                           "libzypp not ready for this.");
+    return NULL;
+  }
+
   const std::string root_str(root);
 
   struct Zypp *zypp = NULL;
@@ -123,6 +130,7 @@ struct Zypp *init_target(const char *root, struct Status *status,
   } catch (zypp::Exception &excpt) {
     status->state = status->STATE_FAILED;
     status->error = strdup(excpt.asUserString().c_str());
+    the_zypp.zypp_pointer = NULL;
     return NULL;
   }
 

--- a/c-layer/lib.cxx
+++ b/c-layer/lib.cxx
@@ -222,7 +222,7 @@ void resolvable_unselect(struct Zypp *_zypp, const char *name, enum RESOLVABLE_K
   status->error = NULL;
 }
 
-struct PatternInfos get_patterns_info(struct PatternNames names, struct Status *status) noexcept {
+struct PatternInfos get_patterns_info(struct Zypp *_zypp, struct PatternNames names, struct Status *status) noexcept {
   PatternInfos result = {
       (struct PatternInfo *)malloc(names.size * sizeof(PatternInfo)),
       0 // initialize with zero and increase after each successfull add of pattern info

--- a/c-layer/lib.cxx
+++ b/c-layer/lib.cxx
@@ -40,6 +40,7 @@ static struct Zypp the_zypp {
 void free_zypp(struct Zypp *zypp) noexcept {
   zypp->zypp_pointer = NULL; // shared ptr assignment operator will free original pointer
   delete (zypp->repo_manager);
+  zypp->repo_manager = NULL;
 }
 
 // helper to get allocated formated string. Sadly C does not provide any portable way to do it.

--- a/c-layer/lib.cxx
+++ b/c-layer/lib.cxx
@@ -1,8 +1,8 @@
 #include "lib.h"
 #include "callbacks.h"
 #include "callbacks.hxx"
-#include "repository.h"
 #include "helpers.hxx"
+#include "repository.h"
 
 #include <cstddef>
 #include <cstdlib>
@@ -163,12 +163,15 @@ static zypp::Resolvable::Kind kind_to_zypp_kind(RESOLVABLE_KIND kind) {
 
 static zypp::ResStatus::TransactByValue transactby_from(enum RESOLVABLE_SELECTED who) {
   switch (who) {
-    case RESOLVABLE_SELECTED::SOLVER_SELECTED: return zypp::ResStatus::SOLVER;
-    case RESOLVABLE_SELECTED::APPLICATION_SELECTED: return zypp::ResStatus::APPL_HIGH;
-    case RESOLVABLE_SELECTED::USER_SELECTED: return zypp::ResStatus::USER;
-    case RESOLVABLE_SELECTED::NOT_SELECTED: {
-      PANIC("Unexpected value RESOLVABLE_SELECTED::NOT_SELECTED.");
-    }
+  case RESOLVABLE_SELECTED::SOLVER_SELECTED:
+    return zypp::ResStatus::SOLVER;
+  case RESOLVABLE_SELECTED::APPLICATION_SELECTED:
+    return zypp::ResStatus::APPL_HIGH;
+  case RESOLVABLE_SELECTED::USER_SELECTED:
+    return zypp::ResStatus::USER;
+  case RESOLVABLE_SELECTED::NOT_SELECTED: {
+    PANIC("Unexpected value RESOLVABLE_SELECTED::NOT_SELECTED.");
+  }
   }
 
   // should not happen
@@ -441,7 +444,7 @@ void import_gpg_key(struct Zypp *zypp, const char *const pathname, struct Status
     // Keys that are unknown (not imported).
     // or known-but-untrusted (weird in-between state, see KeyRing_test.cc)
     // will trigger "Trust this?" callbacks.
-    bool trusted = true;  
+    bool trusted = true;
     zypp->zypp_pointer->keyRing()->importKey(key, trusted);
     status->state = status->STATE_SUCCEED;
     status->error = NULL;

--- a/c-layer/lib.cxx
+++ b/c-layer/lib.cxx
@@ -99,7 +99,7 @@ struct Zypp *init_target(const char *root, struct Status *status,
   if (the_zypp.zypp_pointer != NULL) {
     status->state = status->STATE_FAILED;
     status->error = strdup("Cannot have two init_target concurrently, "
-                           "libzypp not ready for this.");
+                           "libzypp not ready for this. Call free_zypp first.");
     return NULL;
   }
 

--- a/rust/zypp-agama-example/src/main.rs
+++ b/rust/zypp-agama-example/src/main.rs
@@ -56,17 +56,17 @@ fn main() -> Result<(), zypp_agama::ZyppError> {
     let default_root = "/".to_owned();
     let root = args.get(1).unwrap_or(&default_root);
 
-    zypp_agama::init_target(root, |text, step, total| {
+    let z = zypp_agama::init_target(root, |text, step, total| {
         println!("Initializing target: {}/{} - {}", step, total, text)
     })?;
 
     println!("List of existing repositories:");
-    let repos = zypp_agama::list_repositories()?;
+    let repos = zypp_agama::list_repositories(&z)?;
     for repo in repos {
         println!("- Repo {} with url {}", repo.user_name, repo.url);
     }
 
-    zypp_agama::load_source(|percent, text| {
+    zypp_agama::load_source(&z, |percent, text| {
         println!("{}%: {}", percent, text);
         true
     })?;

--- a/rust/zypp-agama-example/src/main.rs
+++ b/rust/zypp-agama-example/src/main.rs
@@ -96,7 +96,7 @@ fn main() -> Result<(), zypp_agama::ZyppError> {
     println!("Non conflicting case. Solver returns {}", res);
 
     let names = vec!["base", "minimal_base"];
-    let res = zypp_agama::patterns_info(names)?;
+    let res = zypp_agama::patterns_info(&zypp, names)?;
     println!("patterns info: {:#?}", res);
 
     Ok(())

--- a/rust/zypp-agama-example/src/main.rs
+++ b/rust/zypp-agama-example/src/main.rs
@@ -56,40 +56,43 @@ fn main() -> Result<(), zypp_agama::ZyppError> {
     let default_root = "/".to_owned();
     let root = args.get(1).unwrap_or(&default_root);
 
-    let z = zypp_agama::init_target(root, |text, step, total| {
+    let zypp = zypp_agama::init_target(root, |text, step, total| {
         println!("Initializing target: {}/{} - {}", step, total, text)
     })?;
 
     println!("List of existing repositories:");
-    let repos = zypp_agama::list_repositories(&z)?;
+    let repos = zypp_agama::list_repositories(&zypp)?;
     for repo in repos {
         println!("- Repo {} with url {}", repo.user_name, repo.url);
     }
 
-    zypp_agama::load_source(&z, |percent, text| {
+    zypp_agama::load_source(&zypp, |percent, text| {
         println!("{}%: {}", percent, text);
         true
     })?;
     // intentionally create conflict
     zypp_agama::select_resolvable(
+        &zypp,
         "ftp",
         ResolvableKind::Package,
         zypp_agama::ResolvableSelected::User,
     )?;
     zypp_agama::select_resolvable(
+        &zypp,
         "tnftp",
         ResolvableKind::Package,
         zypp_agama::ResolvableSelected::User,
     )?;
-    let res = zypp_agama::run_solver()?;
+    let res = zypp_agama::run_solver(&zypp)?;
     println!("Conflict case. Solver returns {}", res);
 
     zypp_agama::unselect_resolvable(
+        &zypp,
         "ftp",
         ResolvableKind::Package,
         zypp_agama::ResolvableSelected::User,
     )?;
-    let res = zypp_agama::run_solver()?;
+    let res = zypp_agama::run_solver(&zypp)?;
     println!("Non conflicting case. Solver returns {}", res);
 
     let names = vec!["base", "minimal_base"];

--- a/rust/zypp-agama-sys/src/bindings.rs
+++ b/rust/zypp-agama-sys/src/bindings.rs
@@ -115,7 +115,7 @@ const _: () = {
 pub struct Zypp {
     _unused: [u8; 0],
 }
-#[doc = " Progress reporting callback used by methods that takes longer.\n @param text  text for user describing what is happening now\n @param stage current stage number starting with 0\n @param total count of stages. It should not change during single call of method.\n @param user_data is never touched by method and is used only to pass local data for callback\n @todo Do we want to support response for callback that allows early exit of execution?"]
+#[doc = " Progress reporting callback used by methods that takes longer.\n @param text  text for user describing what is happening now\n @param stage current stage number starting with 0\n @param total count of stages. It should not change during single call of\n method.\n @param user_data is never touched by method and is used only to pass local\n data for callback\n @todo Do we want to support response for callback that allows early exit of\n execution?"]
 pub type ProgressCallback = ::std::option::Option<
     unsafe extern "C" fn(
         text: *const ::std::os::raw::c_char,
@@ -134,7 +134,7 @@ pub type RESOLVABLE_KIND = ::std::os::raw::c_uint;
 pub const RESOLVABLE_SELECTED_NOT_SELECTED: RESOLVABLE_SELECTED = 0;
 #[doc = " dependency solver select resolvable\n match TransactByValue::SOLVER"]
 pub const RESOLVABLE_SELECTED_SOLVER_SELECTED: RESOLVABLE_SELECTED = 1;
-#[doc = " installation proposal selects resolvable\n match TransactByValue::APPL_{LOW,HIGH} we do not need both, so we use just one value"]
+#[doc = " installation proposal selects resolvable\n match TransactByValue::APPL_{LOW,HIGH} we do not need both, so we use just\n one value"]
 pub const RESOLVABLE_SELECTED_APPLICATION_SELECTED: RESOLVABLE_SELECTED = 2;
 #[doc = " user select resolvable for installation\n match TransactByValue::USER"]
 pub const RESOLVABLE_SELECTED_USER_SELECTED: RESOLVABLE_SELECTED = 3;
@@ -246,14 +246,14 @@ extern "C" {
         user_data: *mut ::std::os::raw::c_void,
     );
     pub fn free_status(s: *mut Status);
-    #[doc = " Initialize Zypp target (where to install packages to).\n The returned zypp context is not thread safe and should be protected by a mutex\n in the calling layer.\n @param root\n @param[out] status\n @param progress\n @param user_data\n @return zypp context"]
+    #[doc = " Initialize Zypp target (where to install packages to).\n The returned zypp context is not thread safe and should be protected by a\n mutex in the calling layer.\n @param root\n @param[out] status\n @param progress\n @param user_data\n @return zypp context"]
     pub fn init_target(
         root: *const ::std::os::raw::c_char,
         status: *mut Status,
         progress: ProgressCallback,
         user_data: *mut ::std::os::raw::c_void,
     ) -> *mut Zypp;
-    #[doc = " Marks resolvable for installation\n @param zypp see \\ref init_target\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do selection. If NOT_SELECTED is used, it will be empty operation.\n @param[out] status (will overwrite existing contents)"]
+    #[doc = " Marks resolvable for installation\n @param zypp see \\ref init_target\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do selection. If NOT_SELECTED is used, it will be empty\n operation.\n @param[out] status (will overwrite existing contents)"]
     pub fn resolvable_select(
         zypp: *mut Zypp,
         name: *const ::std::os::raw::c_char,
@@ -261,7 +261,7 @@ extern "C" {
         who: RESOLVABLE_SELECTED,
         status: *mut Status,
     );
-    #[doc = " Unselect resolvable for installation. It can still be installed as dependency.\n @param zypp see \\ref init_target\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do unselection. Only unselect if it is higher or equal level then who do the selection.\n @param[out] status (will overwrite existing contents)"]
+    #[doc = " Unselect resolvable for installation. It can still be installed as\n dependency.\n @param zypp see \\ref init_target\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do unselection. Only unselect if it is higher or equal level\n then who do the selection.\n @param[out] status (will overwrite existing contents)"]
     pub fn resolvable_unselect(
         zypp: *mut Zypp,
         name: *const ::std::os::raw::c_char,
@@ -269,7 +269,7 @@ extern "C" {
         who: RESOLVABLE_SELECTED,
         status: *mut Status,
     );
-    #[doc = " Get Pattern details.\n Unknown patterns are simply omitted from the result. Match by PatternInfo.name, not by index."]
+    #[doc = " Get Pattern details.\n Unknown patterns are simply omitted from the result. Match by\n PatternInfo.name, not by index."]
     pub fn get_patterns_info(
         _zypp: *mut Zypp,
         names: PatternNames,
@@ -305,7 +305,7 @@ extern "C" {
         callback: ZyppProgressCallback,
         user_data: *mut ::std::os::raw::c_void,
     );
-    #[doc = "\n @param zypp see \\ref init_target\n @param alias alias of repository to refresh\n @param[out] status (will overwrite existing contents)\n @param callbacks pointer to struct with callbacks or NULL if no progress is needed"]
+    #[doc = "\n @param zypp see \\ref init_target\n @param alias alias of repository to refresh\n @param[out] status (will overwrite existing contents)\n @param callbacks pointer to struct with callbacks or NULL if no progress is\n needed"]
     pub fn refresh_repository(
         zypp: *mut Zypp,
         alias: *const ::std::os::raw::c_char,

--- a/rust/zypp-agama-sys/src/bindings.rs
+++ b/rust/zypp-agama-sys/src/bindings.rs
@@ -270,7 +270,11 @@ extern "C" {
         status: *mut Status,
     );
     #[doc = " Get Pattern details.\n Unknown patterns are simply omitted from the result. Match by PatternInfo.name, not by index."]
-    pub fn get_patterns_info(names: PatternNames, status: *mut Status) -> PatternInfos;
+    pub fn get_patterns_info(
+        _zypp: *mut Zypp,
+        names: PatternNames,
+        status: *mut Status,
+    ) -> PatternInfos;
     pub fn free_pattern_infos(infos: *const PatternInfos);
     pub fn import_gpg_key(
         zypp: *mut Zypp,

--- a/rust/zypp-agama-sys/src/bindings.rs
+++ b/rust/zypp-agama-sys/src/bindings.rs
@@ -109,6 +109,12 @@ const _: () = {
     ["Offset of field: Status::state"][::std::mem::offset_of!(Status, state) - 0usize];
     ["Offset of field: Status::error"][::std::mem::offset_of!(Status, error) - 8usize];
 };
+#[doc = " Opaque Zypp context"]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Zypp {
+    _unused: [u8; 0],
+}
 #[doc = " Progress reporting callback used by methods that takes longer.\n @param text  text for user describing what is happening now\n @param stage current stage number starting with 0\n @param total count of stages. It should not change during single call of method.\n @param user_data is never touched by method and is used only to pass local data for callback\n @todo Do we want to support response for callback that allows early exit of execution?"]
 pub type ProgressCallback = ::std::option::Option<
     unsafe extern "C" fn(
@@ -148,6 +154,7 @@ const _: () = {
     ["Offset of field: PatternNames::names"][::std::mem::offset_of!(PatternNames, names) - 0usize];
     ["Offset of field: PatternNames::size"][::std::mem::offset_of!(PatternNames, size) - 8usize];
 };
+#[doc = " Info from zypp::Pattern.\n https://doc.opensuse.org/projects/libzypp/HEAD/classzypp_1_1Pattern.html"]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PatternInfo {
@@ -239,63 +246,78 @@ extern "C" {
         user_data: *mut ::std::os::raw::c_void,
     );
     pub fn free_status(s: *mut Status);
-    #[doc = " Initialize Zypp target (where to install packages to)\n @param root\n @param[out] status\n @param progress\n @param user_data"]
+    #[doc = " Initialize Zypp target (where to install packages to).\n The returned zypp context is not thread safe and should be protected by a mutex\n in the calling layer.\n @param root\n @param[out] status\n @param progress\n @param user_data\n @return zypp context"]
     pub fn init_target(
         root: *const ::std::os::raw::c_char,
         status: *mut Status,
         progress: ProgressCallback,
         user_data: *mut ::std::os::raw::c_void,
-    );
-    #[doc = " Marks resolvable for installation\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do selection. If NOT_SELECTED is used, it will be empty operation.\n @param[out] status (will overwrite existing contents)"]
+    ) -> *mut Zypp;
+    #[doc = " Marks resolvable for installation\n @param zypp see \\ref init_target\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do selection. If NOT_SELECTED is used, it will be empty operation.\n @param[out] status (will overwrite existing contents)"]
     pub fn resolvable_select(
+        zypp: *mut Zypp,
         name: *const ::std::os::raw::c_char,
         kind: RESOLVABLE_KIND,
         who: RESOLVABLE_SELECTED,
         status: *mut Status,
     );
-    #[doc = " Unselect resolvable for installation. It can still be installed as dependency.\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do unselection. Only unselect if it is higher or equal level then who do the selection.\n @param[out] status (will overwrite existing contents)"]
+    #[doc = " Unselect resolvable for installation. It can still be installed as dependency.\n @param zypp see \\ref init_target\n @param name resolvable name\n @param kind kind of resolvable\n @param who who do unselection. Only unselect if it is higher or equal level then who do the selection.\n @param[out] status (will overwrite existing contents)"]
     pub fn resolvable_unselect(
+        zypp: *mut Zypp,
         name: *const ::std::os::raw::c_char,
         kind: RESOLVABLE_KIND,
         who: RESOLVABLE_SELECTED,
         status: *mut Status,
     );
+    #[doc = " Get Pattern details.\n Unknown patterns are simply omitted from the result. Match by PatternInfo.name, not by index."]
     pub fn get_patterns_info(names: PatternNames, status: *mut Status) -> PatternInfos;
     pub fn free_pattern_infos(infos: *const PatternInfos);
-    pub fn import_gpg_key(pathname: *const ::std::os::raw::c_char, status: *mut Status);
-    #[doc = " Runs solver\n @param[out] status (will overwrite existing contents)\n @return true if solver pass and false if it found some dependency issues"]
-    pub fn run_solver(status: *mut Status) -> bool;
+    pub fn import_gpg_key(
+        zypp: *mut Zypp,
+        pathname: *const ::std::os::raw::c_char,
+        status: *mut Status,
+    );
+    #[doc = " Runs solver\n @param zypp see \\ref init_target\n @param[out] status (will overwrite existing contents)\n @return true if solver pass and false if it found some dependency issues"]
+    pub fn run_solver(zypp: *mut Zypp, status: *mut Status) -> bool;
     #[doc = " the last call that will free all pointers to zypp holded by agama"]
-    pub fn free_zypp();
-    #[doc = " repository array in list.\n when no longer needed, use \\ref free_repository_list to release memory\n @param[out] status (will overwrite existing contents)"]
-    pub fn list_repositories(status: *mut Status) -> RepositoryList;
+    pub fn free_zypp(zypp: *mut Zypp);
+    #[doc = " repository array in list.\n when no longer needed, use \\ref free_repository_list to release memory\n @param zypp see \\ref init_target\n @param[out] status (will overwrite existing contents)"]
+    pub fn list_repositories(zypp: *mut Zypp, status: *mut Status) -> RepositoryList;
     pub fn free_repository_list(repo_list: *mut RepositoryList);
-    #[doc = " Adds repository to repo manager\n @param alias have to be unique\n @param url can contain repo variables\n @param[out] status (will overwrite existing contents)\n @param callback pointer to function with callback or NULL\n @param user_data"]
+    #[doc = " Adds repository to repo manager\n @param zypp see \\ref init_target\n @param alias have to be unique\n @param url can contain repo variables\n @param[out] status (will overwrite existing contents)\n @param callback pointer to function with callback or NULL\n @param user_data"]
     pub fn add_repository(
+        zypp: *mut Zypp,
         alias: *const ::std::os::raw::c_char,
         url: *const ::std::os::raw::c_char,
         status: *mut Status,
         callback: ZyppProgressCallback,
         user_data: *mut ::std::os::raw::c_void,
     );
-    #[doc = " Removes repository from repo manager\n @param alias have to be unique\n @param[out] status (will overwrite existing contents)\n @param callback pointer to function with callback or NULL\n @param user_data"]
+    #[doc = " Removes repository from repo manager\n @param zypp see \\ref init_target\n @param alias have to be unique\n @param[out] status (will overwrite existing contents)\n @param callback pointer to function with callback or NULL\n @param user_data"]
     pub fn remove_repository(
+        zypp: *mut Zypp,
         alias: *const ::std::os::raw::c_char,
         status: *mut Status,
         callback: ZyppProgressCallback,
         user_data: *mut ::std::os::raw::c_void,
     );
-    #[doc = "\n @param alias alias of repository to refresh\n @param[out] status (will overwrite existing contents)\n @param callbacks pointer to struct with callbacks or NULL if no progress is needed"]
+    #[doc = "\n @param zypp see \\ref init_target\n @param alias alias of repository to refresh\n @param[out] status (will overwrite existing contents)\n @param callbacks pointer to struct with callbacks or NULL if no progress is needed"]
     pub fn refresh_repository(
+        zypp: *mut Zypp,
         alias: *const ::std::os::raw::c_char,
         status: *mut Status,
         callbacks: *mut DownloadProgressCallbacks,
     );
     pub fn build_repository_cache(
+        zypp: *mut Zypp,
         alias: *const ::std::os::raw::c_char,
         status: *mut Status,
         callback: ZyppProgressCallback,
         user_data: *mut ::std::os::raw::c_void,
     );
-    pub fn load_repository_cache(alias: *const ::std::os::raw::c_char, status: *mut Status);
+    pub fn load_repository_cache(
+        zypp: *mut Zypp,
+        alias: *const ::std::os::raw::c_char,
+        status: *mut Status,
+    );
 }

--- a/rust/zypp-agama-sys/src/lib.rs
+++ b/rust/zypp-agama-sys/src/lib.rs
@@ -6,6 +6,9 @@ include!("bindings.rs");
 
 impl Default for Status {
     fn default() -> Self {
-        Self { state: Status_STATE_STATE_SUCCEED, error: std::ptr::null_mut() }
+        Self {
+            state: Status_STATE_STATE_SUCCEED,
+            error: std::ptr::null_mut(),
+        }
     }
 }

--- a/rust/zypp-agama/src/errors.rs
+++ b/rust/zypp-agama/src/errors.rs
@@ -4,18 +4,20 @@ pub type ZyppResult<A> = Result<A, ZyppError>;
 
 #[derive(Debug)]
 pub struct ZyppError {
-    details: String
+    details: String,
 }
 
 impl ZyppError {
     pub fn new(msg: &str) -> ZyppError {
-        ZyppError{details: msg.to_string()}
+        ZyppError {
+            details: msg.to_string(),
+        }
     }
 }
 
 impl fmt::Display for ZyppError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,"{}",self.details)
+        write!(f, "{}", self.details)
     }
 }
 

--- a/rust/zypp-agama/src/helpers.rs
+++ b/rust/zypp-agama/src/helpers.rs
@@ -1,15 +1,18 @@
-
 // Safety requirements: inherited from https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_ptr
 pub(crate) unsafe fn string_from_ptr(c_ptr: *const i8) -> String {
     String::from_utf8_lossy(std::ffi::CStr::from_ptr(c_ptr).to_bytes()).into_owned()
 }
 
 // Safety requirements: ...
-pub(crate) unsafe fn status_to_result_void(mut status: zypp_agama_sys::Status) -> Result<(), crate::ZyppError> {
+pub(crate) unsafe fn status_to_result_void(
+    mut status: zypp_agama_sys::Status,
+) -> Result<(), crate::ZyppError> {
     let res = if status.state == zypp_agama_sys::Status_STATE_STATE_SUCCEED {
         Ok(())
     } else {
-        Err(crate::ZyppError::new(string_from_ptr(status.error).as_str()))
+        Err(crate::ZyppError::new(
+            string_from_ptr(status.error).as_str(),
+        ))
     };
     let status_ptr = &mut status;
     zypp_agama_sys::free_status(status_ptr as *mut _);

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -249,7 +249,11 @@ impl Into<zypp_agama_sys::RESOLVABLE_KIND> for ResolvableKind {
     }
 }
 
-pub fn select_resolvable(name: &str, kind: ResolvableKind, who: ResolvableSelected) -> ZyppResult<()> {
+pub fn select_resolvable(
+    name: &str,
+    kind: ResolvableKind,
+    who: ResolvableSelected,
+) -> ZyppResult<()> {
     unsafe {
         let mut status: Status = Status::default();
         let status_ptr = &mut status as *mut _;
@@ -260,7 +264,11 @@ pub fn select_resolvable(name: &str, kind: ResolvableKind, who: ResolvableSelect
     }
 }
 
-pub fn unselect_resolvable(name: &str, kind: ResolvableKind, who: ResolvableSelected) -> ZyppResult<()> {
+pub fn unselect_resolvable(
+    name: &str,
+    kind: ResolvableKind,
+    who: ResolvableSelected,
+) -> ZyppResult<()> {
     unsafe {
         let mut status: Status = Status::default();
         let status_ptr = &mut status as *mut _;

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -430,8 +430,8 @@ mod tests {
     use std::error::Error;
     use std::process::Command;
 
-    fn progress_cb(_text: String, _stage: u32, _total: u32) {
-        // for test do nothing..maybe some check of callbacks?
+    fn progress_cb(_text: String, _step: u32, _total: u32) {
+        // println!("Test initializing target: {}/{} - {}", _step, _total, _text)
     }
 
     #[test]

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{
     ffi::CString,
     os::raw::{c_char, c_uint, c_void},
-    sync::{Mutex, MutexGuard, TryLockError},
 };
 
 pub use callbacks::DownloadProgress;
@@ -17,6 +16,8 @@ mod helpers;
 use helpers::{status_to_result_void, string_from_ptr};
 
 mod callbacks;
+mod zypp;
+use zypp::Zypp;
 
 #[derive(Debug)]
 pub struct Repository {
@@ -63,84 +64,6 @@ where
     F: FnMut(String, u32, u32),
 {
     Some(progress_callback::<F>)
-}
-
-// Mutex for the Zypp C API which is not thread safe.
-// TODO: guard some (global) context instead of ().
-//static ZYPP_MUTEX: Mutex<*mut zypp_agama_sys::Zypp> = Mutex::new(std::ptr::null_mut());
-static ZYPP_MUTEX: Mutex<()> = Mutex::new(());
-pub struct Zypp<'a> {
-    // underscore prevents
-    //     warning: field `guard` is never read
-    _guard: MutexGuard<'a, ()>,
-    // stupid spelling, attempt to prevent private access
-    in_ner: *mut zypp_agama_sys::Zypp,
-}
-
-impl<'a> Zypp<'a> {
-    // Create Self, locking the Mutex (delaying and retrying a few times before panicking).
-    //
-    // Usage:
-    // ```
-    // let mut zypp = Zypp::lock();
-    // let inner_zypp = zypp_agama_sys::init_target(...);
-    // zypp.set(inner_zypp);
-    // ```
-    //
-    // Using `lock()`+`set(inner)` instead of `new(inner)` lets us
-    // avoid locks on the C side
-    pub fn lock() -> Self {
-        let mut delay = std::time::Duration::from_millis(10);
-        let mut tries = 8;
-        // Exponential backoff, will wait at most (2**(tries-1) - 1) * delay
-        // Which is 1.27s for now. Increase *tries* if needed.
-        loop {
-            let result = ZYPP_MUTEX.try_lock();
-            if let Ok(guard) = result {
-                // println!("creating Zypp");
-                return Self {
-                    _guard: guard,
-                    in_ner: std::ptr::null_mut(),
-                };
-            }
-
-            match result.unwrap_err() {
-                TryLockError::Poisoned(_) => {
-                    panic!("Another thread had the ZYPP_MUTEX, and panicked.")
-                }
-                TryLockError::WouldBlock => {
-                    tries -= 1;
-                    if tries <= 0 {
-                        panic!("Another thread had the ZYPP_MUTEX for too long.");
-                    }
-                }
-            }
-
-            // println!("delaying {:?}", delay);
-            std::thread::sleep(delay);
-            delay = delay.mul_f64(2.0);
-        }
-    }
-
-    pub fn set(&mut self, inner: *mut zypp_agama_sys::Zypp) {
-        self.in_ner = inner;
-    }
-
-    pub fn inner(&self) -> *mut zypp_agama_sys::Zypp {
-        assert!(!self.in_ner.is_null());
-        self.in_ner
-    }
-}
-
-impl Drop for Zypp<'_> {
-    fn drop(&mut self) {
-        // println!("dropping Zypp");
-        unsafe {
-            if !self.in_ner.is_null() {
-                zypp_agama_sys::free_zypp(self.in_ner);
-            }
-        }
-    }
 }
 
 pub fn init_target<F>(root: &str, progress: F) -> ZyppResult<Zypp>

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -108,7 +108,11 @@ impl<'a> Zypp<'a> {
 impl Drop for Zypp<'_> {
     fn drop(&mut self) {
         // println!("dropping Zypp");
-        // TODO: call free_zypp here
+        unsafe {
+            if !self.in_ner.is_null() {
+                zypp_agama_sys::free_zypp(self.in_ner);
+            }
+        }
     }
 }
 
@@ -483,7 +487,6 @@ mod tests {
     #[test]
     fn init_target_ok() -> Result<(), Box<dyn Error>> {
         init_target("/", progress_cb)?;
-        // TODO: free_zypp, don't leak RepoManager
         Ok(())
     }
 

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -370,7 +370,7 @@ pub struct PatternInfo {
     pub selected: ResolvableSelected,
 }
 
-pub fn patterns_info(names: Vec<&str>) -> ZyppResult<Vec<PatternInfo>> {
+pub fn patterns_info(zypp: &Zypp, names: Vec<&str>) -> ZyppResult<Vec<PatternInfo>> {
     unsafe {
         let mut status: Status = Status::default();
         let status_ptr = &mut status as *mut _;
@@ -383,7 +383,7 @@ pub fn patterns_info(names: Vec<&str>) -> ZyppResult<Vec<PatternInfo>> {
             size: names.len() as u32,
             names: c_ptr_names.as_ptr(),
         };
-        let infos = get_patterns_info(pattern_names, status_ptr);
+        let infos = get_patterns_info(zypp.inner(), pattern_names, status_ptr);
         helpers::status_to_result_void(status)?;
 
         let mut r_infos = Vec::with_capacity(infos.size as usize);

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -448,6 +448,14 @@ mod tests {
     }
 
     #[test]
+    fn init_target_err2() -> Result<(), Box<dyn Error>> {
+        // a nonexistent relative root triggers a C++ exception
+        let result = init_target("not_absolute", progress_cb);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
     #[should_panic(expected = "ZYPP_MUTEX for too long")]
     fn init_target_deadlock() {
         // Let other test threads succeed before we hog the Mutex.

--- a/rust/zypp-agama/src/zypp.rs
+++ b/rust/zypp-agama/src/zypp.rs
@@ -8,8 +8,7 @@ pub struct Zypp<'a> {
     // underscore prevents
     //     warning: field `guard` is never read
     _guard: MutexGuard<'a, ()>,
-    // stupid spelling, attempt to prevent private access
-    in_ner: *mut zypp_agama_sys::Zypp,
+    inner: *mut zypp_agama_sys::Zypp,
 }
 
 impl<'a> Zypp<'a> {
@@ -35,7 +34,7 @@ impl<'a> Zypp<'a> {
                 // println!("creating Zypp");
                 return Self {
                     _guard: guard,
-                    in_ner: std::ptr::null_mut(),
+                    inner: std::ptr::null_mut(),
                 };
             }
 
@@ -58,12 +57,12 @@ impl<'a> Zypp<'a> {
     }
 
     pub fn set(&mut self, inner: *mut zypp_agama_sys::Zypp) {
-        self.in_ner = inner;
+        self.inner = inner;
     }
 
     pub fn inner(&self) -> *mut zypp_agama_sys::Zypp {
-        assert!(!self.in_ner.is_null());
-        self.in_ner
+        assert!(!self.inner.is_null());
+        self.inner
     }
 }
 
@@ -71,8 +70,8 @@ impl Drop for Zypp<'_> {
     fn drop(&mut self) {
         // println!("dropping Zypp");
         unsafe {
-            if !self.in_ner.is_null() {
-                zypp_agama_sys::free_zypp(self.in_ner);
+            if !self.inner.is_null() {
+                zypp_agama_sys::free_zypp(self.inner);
             }
         }
     }

--- a/rust/zypp-agama/src/zypp.rs
+++ b/rust/zypp-agama/src/zypp.rs
@@ -1,0 +1,79 @@
+use std::sync::{Mutex, MutexGuard, TryLockError};
+
+// Mutex for the Zypp C API which is not thread safe.
+// TODO: guard some (global) context instead of ().
+//static ZYPP_MUTEX: Mutex<*mut zypp_agama_sys::Zypp> = Mutex::new(std::ptr::null_mut());
+static ZYPP_MUTEX: Mutex<()> = Mutex::new(());
+pub struct Zypp<'a> {
+    // underscore prevents
+    //     warning: field `guard` is never read
+    _guard: MutexGuard<'a, ()>,
+    // stupid spelling, attempt to prevent private access
+    in_ner: *mut zypp_agama_sys::Zypp,
+}
+
+impl<'a> Zypp<'a> {
+    // Create Self, locking the Mutex (delaying and retrying a few times before panicking).
+    //
+    // Usage:
+    // ```
+    // let mut zypp = Zypp::lock();
+    // let inner_zypp = zypp_agama_sys::init_target(...);
+    // zypp.set(inner_zypp);
+    // ```
+    //
+    // Using `lock()`+`set(inner)` instead of `new(inner)` lets us
+    // avoid locks on the C side
+    pub fn lock() -> Self {
+        let mut delay = std::time::Duration::from_millis(10);
+        let mut tries = 8;
+        // Exponential backoff, will wait at most (2**(tries-1) - 1) * delay
+        // Which is 1.27s for now. Increase *tries* if needed.
+        loop {
+            let result = ZYPP_MUTEX.try_lock();
+            if let Ok(guard) = result {
+                // println!("creating Zypp");
+                return Self {
+                    _guard: guard,
+                    in_ner: std::ptr::null_mut(),
+                };
+            }
+
+            match result.unwrap_err() {
+                TryLockError::Poisoned(_) => {
+                    panic!("Another thread had the ZYPP_MUTEX, and panicked.")
+                }
+                TryLockError::WouldBlock => {
+                    tries -= 1;
+                    if tries <= 0 {
+                        panic!("Another thread had the ZYPP_MUTEX for too long.");
+                    }
+                }
+            }
+
+            // println!("delaying {:?}", delay);
+            std::thread::sleep(delay);
+            delay = delay.mul_f64(2.0);
+        }
+    }
+
+    pub fn set(&mut self, inner: *mut zypp_agama_sys::Zypp) {
+        self.in_ner = inner;
+    }
+
+    pub fn inner(&self) -> *mut zypp_agama_sys::Zypp {
+        assert!(!self.in_ner.is_null());
+        self.in_ner
+    }
+}
+
+impl Drop for Zypp<'_> {
+    fn drop(&mut self) {
+        // println!("dropping Zypp");
+        unsafe {
+            if !self.in_ner.is_null() {
+                zypp_agama_sys::free_zypp(self.in_ner);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This went ahead in #7:
> Adding a `make check` target. (`check` is an autotools convention, from the GNU make standards BTW)

Yay, adding a `Mutex` does work out, if its `MutexGuard` is held by a `Zypp` context object