### PR TITLE
fix: detect rustc-link-search using CARGO_MANIFEST_DIR

### DIFF
--- a/rust/zypp-agama-sys/build.rs
+++ b/rust/zypp-agama-sys/build.rs
@@ -1,5 +1,11 @@
+use std::{env, path::Path};
+
 fn main() {
-    println!("cargo::rustc-link-search=native=../c-layer/");
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    println!(
+        "cargo::rustc-link-search=native={}",
+        Path::new(&manifest_dir).join("../../c-layer").display()
+    );
     println!("cargo::rustc-link-lib=static=agama-zypp");
     println!("cargo::rustc-link-lib=dylib=zypp");
     // NOTE: install the matching library for your compiler version, for example


### PR DESCRIPTION
Improve the detection of `libagama-zypp.a` path so it can be used outside of the workspace.
