### PR TITLE
add structs to hold installation proposals

### DIFF
--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -16,6 +16,7 @@ mod helpers;
 use helpers::{status_to_result_void, string_from_ptr};
 
 mod callbacks;
+pub mod proposal;
 
 #[derive(Debug)]
 pub struct Repository {
@@ -200,6 +201,7 @@ pub fn load_repo_cache(alias: &str) -> ZyppResult<()> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum ResolvableKind {
     Package,
     Pattern,
@@ -242,7 +244,7 @@ pub fn unselect_resolvable(name: &str, kind: ResolvableKind, who: ResolvableSele
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ResolvableSelected {
     Not,
     User,

--- a/rust/zypp-agama/src/proposal.rs
+++ b/rust/zypp-agama/src/proposal.rs
@@ -39,6 +39,8 @@ pub struct Areas {
 }
 
 impl Areas {
+    /// Sets for given id requirements. It will try to satisfy requirements and also if given
+    /// id contain old requirements, unselects them.
     pub fn set_resolvables(&mut self, id: &str, requirements: Requirements) -> ZyppResult<()> {
         let key = id.to_string();
         if let Some(old) = self.map.get(&key) {

--- a/rust/zypp-agama/src/proposal.rs
+++ b/rust/zypp-agama/src/proposal.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+
+
+use crate::{errors::ZyppResult, select_resolvable, unselect_resolvable, ResolvableKind};
+
+/// Captures list of required resolvables
+pub struct Requirements {
+    /// Type of resolvable
+    /// If requirement needs different kinds, then define
+    ///  more areas like bootloader_patterns, bootloader_packages
+    kind: ResolvableKind,
+    /// List of resolvables
+    resolvables: Vec<String>,
+    /// if not satisfied requirement is fatal or not
+    optional: bool,
+}
+
+impl Requirements {
+    pub fn select(&self) -> ZyppResult<()> {
+        for res in &self.resolvables {
+            select_resolvable(&res, self.kind, crate::ResolvableSelected::Installation)?;
+            // TODO: do not fail for missing optional package
+        }
+        Ok(())
+    }
+
+    pub fn unselect(&self) -> ZyppResult<()> {
+        for res in &self.resolvables {
+            unselect_resolvable(&res, self.kind, crate::ResolvableSelected::Installation)?;
+            // TODO: do not fail for missing optional package
+        }
+        Ok(())
+    }
+}
+
+/// Keeps requirements for different areas
+pub struct Areas {
+    map: HashMap<String, Requirements>,
+}
+
+impl Areas {
+    pub fn set_resolvables(&mut self, id: &str, requirements: Requirements) -> ZyppResult<()> {
+        let key = id.to_string();
+        if let Some(old) = self.map.get(&key) {
+            old.unselect()?;
+        }
+        requirements.select()?;
+        self.map.insert(key, requirements);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Idea is to have in rust part counterpart of Yast::PackagesProposal. So there is now two new structs. One is for capturing requirements and second is for capturing mapping  between id and its requirements.