### PR TITLE
add to build script also build of static library

### DIFF
--- a/rust/zypp-agama-sys/build.rs
+++ b/rust/zypp-agama-sys/build.rs
@@ -1,7 +1,14 @@
-use std::{env, path::Path};
+use std::{env, path::Path, process::Command};
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut cmd = Command::new("make");
+    cmd.arg("-C");
+    cmd.arg(Path::new(&manifest_dir).join("../../c-layer").as_os_str());
+    if let Err(e) = cmd.output() {
+        panic!("Building C library failed: {}\n", e.to_string().as_str());
+    }
+
     println!(
         "cargo::rustc-link-search=native={}",
         Path::new(&manifest_dir).join("../../c-layer").display()


### PR DESCRIPTION
Reason is to have smooth cargo build when static library is not manually built.