### PR TITLE
build.rs: avoid needless rebuilds of bindings.rs

### DIFF
--- a/rust/zypp-agama-sys/build.rs
+++ b/rust/zypp-agama-sys/build.rs
@@ -1,5 +1,24 @@
 use bindgen::builder;
-use std::{env, path::Path, process::Command};
+use std::{env, fs, path::Path, process::Command};
+
+// Write *contents* to *file_path* (panicking on problems)
+// but do not update existing file if the exact contents is already there.
+// Thus prevent needless rebuilds.
+fn update_file(file_path: &str, contents: &str) {
+    let should_write = if Path::new(file_path).exists() {
+        match fs::read_to_string(file_path) {
+            Ok(existing_content) => existing_content != contents,
+            Err(_) => true, // File exists but can't read it, write anyway
+        }
+    } else {
+        true // File doesn't exist, write it
+    };
+
+    if should_write {
+        fs::write(file_path, contents)
+            .unwrap_or_else(|_| panic!("Couldn't write {}", file_path));
+    }
+}
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -18,9 +37,7 @@ fn main() {
         .clang_arg("../../c-layer/include")
         .generate()
         .expect("Unable to generate bindings");
-    bindings
-        .write_to_file("src/bindings.rs")
-        .expect("Couldn't write bindings!");
+    update_file("src/bindings.rs", &bindings.to_string());
 
     println!(
         "cargo::rustc-link-search=native={}",


### PR DESCRIPTION
Problem: if you run `cargo test` repeatedly, you will notice that it compiles too many things

Solution: don't write bindings.rs again and again if it already contains the same contents

Follow up to #15 