### PR TITLE
Do not use panicking for failed init of zypp

### DIFF
--- a/c-layer/lib.cxx
+++ b/c-layer/lib.cxx
@@ -38,6 +38,8 @@ static struct Zypp the_zypp {
 };
 
 void free_zypp(struct Zypp *zypp) noexcept {
+  // ensure that target is unloaded otherwise nasty things can happen if new zypp is created in different thread
+  zypp->zypp_pointer->getTarget()->unload();
   zypp->zypp_pointer =
       NULL; // shared ptr assignment operator will free original pointer
   delete (zypp->repo_manager);

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,0 @@
-[env]
-RUST_TEST_THREADS = "1"

--- a/rust/zypp-agama/src/lib.rs
+++ b/rust/zypp-agama/src/lib.rs
@@ -497,7 +497,8 @@ mod tests {
         }
         {
             setup();
-            let result = Zypp::init_target("/nosuchdir", progress_cb);
+            // when the target pathis not a (potential) root diretory
+            let result = Zypp::init_target("/dev/full", progress_cb);
             assert!(result.is_err());
         }
         {


### PR DESCRIPTION
Instead return ZyppError to allow nicer handling of library user and also making tests concurent.